### PR TITLE
Feat support deadline for eat process

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Developer will encounter the need to quickly occupy CPU and memory, I am also de
 # Todo
 
 - [x] Support `eat -c 35%` and `eat -m 35%`
+- [x] support gracefully exit: capture process signal SIGINT(2), SIGTERM(15)
+- [x] support deadline: `-t` specify the duration eat progress. such as "300ms", "1.5h", "2h45m". (unit: "ns", "us" (or "µs"), "ms", "s", "m", "h")
 - [] CPU Affinity
 - [] Memory read/write, prevent memory from being swapped out
 - [] Dynamic adjustment of CPU and memory usage
@@ -24,6 +26,7 @@ eat -m 100%         # eating all memory
 eat -c 2.5 -m 1.5g  # eating 2.5 CPU core and 1.5GB memory
 eat -c 3 -m 200m    # eating 3 CPU core and 200MB memory
 eat -c 100% -m 100% # eating all CPU core and memory
+eat -c 100% -t 1h # eating all CPU core and quit after 1hour
 ```
 
 > Tips:
@@ -43,6 +46,8 @@ go build -o eat
 # 待办
 
 - [x] 支持`eat -c 35%`和`eat -m 35%`
+- [x] 支持优雅退出: 捕捉进程 SIGINT, SIGTERM 信号实现有序退出
+- [x] 支持时限: `-t` 限制吃资源的时间，示例 "300ms", "1.5h", "2h45m". (单位: "ns", "us" (or "µs"), "ms", "s", "m", "h")
 - [] CPU亲和性
 - [] 内存读写，防止内存被交换出去
 - [] 动态调整CPU和内存使用
@@ -61,6 +66,7 @@ eat -m 100%         # 占用所有内存
 eat -c 2.5 -m 1.5g  # 占用2.5个CPU核和1.5GB内存
 eat -c 3 -m 200m    # 占用3个CPU核和200MB内存
 eat -c 100% -m 100% # 占用所有CPU核和内存
+eat -c 100% -t 1h   # 占用所有CPU核并在一小时后退出
 ```
 
 > 提示：

--- a/cmd/cpu.go
+++ b/cmd/cpu.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"math"
 	"runtime"
 	"sync"
 	"time"
@@ -28,8 +29,20 @@ func busyWork(ctx context.Context) {
 }
 
 func partialBusyWork(ctx context.Context, ratio float64) {
-	busyDuration := time.Duration(ratio*10) * time.Millisecond
-	idleDuration := time.Duration((1-ratio)*10) * time.Millisecond
+	const (
+		oneCycle  = 10 * time.Microsecond
+		precision = 1000
+	)
+	// round busy and idle percent
+	// case 1: ratio 0.8
+	//   busy 0.8                     idle 0.19999999999999996
+	//   busyRound 8ms                idleRound 2ms
+	//
+	// case 2: ratio 0.2
+	//   busy 0.16000000000000014     idle 0.8399999999999999
+	//   buseRound 1.6ms              idleRound 8.4ms
+	busyDuration := time.Duration(math.Floor(ratio*precision)) * oneCycle
+	idleDuration := time.Duration(math.Ceil((1-ratio)*precision)) * oneCycle
 	cnt := 0
 	for {
 		// Busy period
@@ -80,5 +93,5 @@ func eatCPU(ctx context.Context, c float64) {
 		}()
 	}
 
-	fmt.Printf("Ate %2.1f CPU cores\n", c)
+	fmt.Printf("Ate %2.3f CPU cores\n", c)
 }

--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -1,6 +1,8 @@
 package cmd
 
-import "fmt"
+import (
+	"fmt"
+)
 
 func eatMemory(memoryBytes uint64) {
 	if memoryBytes == 0 {
@@ -8,7 +10,7 @@ func eatMemory(memoryBytes uint64) {
 	}
 
 	memoryBlock := make([]byte, memoryBytes)
-	fmt.Printf("Eating memory...          ")
+	fmt.Printf("Eating %-12s", "memory...")
 	for i := range memoryBlock {
 		memoryBlock[i] = byte(i % 256)
 	}

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/pbnjay/memory"
 	"runtime"
 	"strconv"
+	"time"
+
+	"github.com/pbnjay/memory"
 )
 
 func parseEatCPUCount(c string) float64 {
@@ -66,4 +68,15 @@ func parseEatMemoryBytes(m string) uint64 {
 		}
 	}
 	return 0
+}
+
+func parseEatDeadline(eta string) time.Duration {
+	duration, err := time.ParseDuration(eta)
+	if err != nil {
+		return time.Duration(0)
+	}
+	if duration <= 0 {
+		return time.Duration(0)
+	}
+	return duration
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -92,7 +92,7 @@ func eatFunction(cmd *cobra.Command, _ []string) {
 	dlEat := parseEatDeadline(dl)
 
 	rootCtx, cancel := getRootContext(dlEat)
-	fmt.Printf("Want to eat %2.1fCPU, %s Memory\n", cEat, m)
+	fmt.Printf("Want to eat %2.3fCPU, %s Memory\n", cEat, m)
 	eatMemory(mEat)
 	eatCPU(rootCtx, cEat)
 	waitUtil(rootCtx, cancel, dlEat)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -28,10 +29,20 @@ var RootCmd = &cobra.Command{
 	Run:   eatFunction,
 }
 
-func waitUtil(ctx context.Context, ctxCancel context.CancelFunc) {
+func getConsoleHelpTips(deadline time.Duration) string {
+	var helpTips = []string{"Press Ctrl + C to exit"}
+	if deadline > 0 {
+		eta := time.Now().Add(deadline)
+		helpTips = append(helpTips, fmt.Sprintf("or wait it util deadline %s", eta.Format(time.DateTime)))
+	}
+	helpTips = append(helpTips, "...")
+	return strings.Join(helpTips, " ")
+}
+
+func waitUtil(ctx context.Context, ctxCancel context.CancelFunc, deadline time.Duration) {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
-	fmt.Println("Press Ctrl + C to exit...")
+	log.Println(getConsoleHelpTips(deadline))
 
 	for {
 		select {
@@ -84,5 +95,5 @@ func eatFunction(cmd *cobra.Command, _ []string) {
 	fmt.Printf("Want to eat %2.1fCPU, %s Memory\n", cEat, m)
 	eatMemory(mEat)
 	eatCPU(rootCtx, cEat)
-	waitUtil(rootCtx, cancel)
+	waitUtil(rootCtx, cancel, dlEat)
 }

--- a/main.go
+++ b/main.go
@@ -1,22 +1,19 @@
 package main
 
 import (
-	"eat/cmd"
 	"fmt"
 	"os"
-)
 
-var (
-	c string // how many cpu would you want eat
-	m string // how many memory would you want eat
+	"eat/cmd"
 )
 
 func main() {
 	rootCmd := cmd.RootCmd
 
 	// Add global flags
-	rootCmd.PersistentFlags().StringVarP(&c, "cpu_usage", "c", "0", "How many cpu would you want eat")
-	rootCmd.PersistentFlags().StringVarP(&m, "memory_usage", "m", "0m", "How many memory would you want eat(GB)")
+	rootCmd.PersistentFlags().StringP("cpu_usage", "c", "0", "How many cpu would you want eat")
+	rootCmd.PersistentFlags().StringP("memory_usage", "m", "0m", "How many memory would you want eat(GB)")
+	rootCmd.PersistentFlags().StringP("time_deadline", "t", "24h", "deadline to quit eat process")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)

--- a/main.go
+++ b/main.go
@@ -13,7 +13,8 @@ func main() {
 	// Add global flags
 	rootCmd.PersistentFlags().StringP("cpu_usage", "c", "0", "How many cpu would you want eat")
 	rootCmd.PersistentFlags().StringP("memory_usage", "m", "0m", "How many memory would you want eat(GB)")
-	rootCmd.PersistentFlags().StringP("time_deadline", "t", "24h", "deadline to quit eat process")
+	// such as "300ms", "1.5h", "2h45m". (unit: "ns", "us" (or "µs"), "ms", "s", "m", "h")
+	rootCmd.PersistentFlags().StringP("time_deadline", "t", "0", "deadline to quit eat process")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Hi Shawn:

New Feature:
- [x] support gracefully exit: call `cancel()` of context when capture process signal SIGINT(2), SIGTERM(15)
- [x] support deadline: `-t` specify the duration eat progress. such as "300ms", "1.5h", "2h45m". (unit: "ns", "us" (or "µs"), "ms", "s", "m", "h"). so User don't need to Ctrl+C manually.

Fix Bugs:
- [X] resolve precision loss when calc busy and idle duration by radio in `partialBusyWork`

Notice: precision loss happen when direct convert float to duration(int), then will lead to cpu usage calculation error. 
 
for example: ratio is `0.8`. 
the busyDuration = int(0.8 * 10)  = 8ms (correct)
but idleDuration = int(0.19999999999999996 * 10) = int(1.9999999999999996) = 1ms (**it should be 2ms**)

Buggy Code:
```go
	busyDuration := time.Duration(ratio*10) * time.Millisecond
	idleDuration := time.Duration((1-ratio)*10) * time.Millisecond
```

Correct Code: (keep three decimal digits of float before convesion)
```go
func partialBusyWork(ctx context.Context, ratio float64) {
	const (
		oneCycle  = 10 * time.Microsecond
		precision = 1000
	)
	// round busy and idle percent
	// case 1: ratio 0.8
	//   busy 0.8                     idle 0.19999999999999996
	//   busyRound 8ms                idleRound 2ms
	//
	// case 2: ratio 0.2
	//   busy 0.16000000000000014     idle 0.8399999999999999
	//   busyRound 1.6ms              idleRound 8.4ms
	busyDuration := time.Duration(math.Floor(ratio*precision)) * oneCycle
	idleDuration := time.Duration(math.Ceil((1-ratio)*precision)) * oneCycle
```

Thanks for your review.