### PR TITLE
Feat prevent ate memory from being swapped out

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Developer will encounter the need to quickly occupy CPU and memory, I am also de
 
 - [x] Support `eat -c 35%` and `eat -m 35%`
 - [x] support gracefully exit: capture process signal SIGINT(2), SIGTERM(15)
-- [x] support deadline: `-t` specify the duration eat progress. such as "300ms", "1.5h", "2h45m". (unit: "ns", "us" (or "µs"), "ms", "s", "m", "h")
-- [] CPU Affinity
-- [] Memory read/write, prevent memory from being swapped out
-- [] Dynamic adjustment of CPU and memory usage
-- [] Eat GPU
+- [x] support deadline: `-t` specify the duration of eat progress. such as "300ms", "1.5h", "2h45m". (unit: "ns", "us" (or "µs"), "ms", "s", "m", "h")
+- [ ] CPU Affinity
+- [x] Memory read/write periodically , prevent memory from being swapped out
+- [ ] Dynamic adjustment of CPU and memory usage
+- [ ] Eat GPU
 
 # Usage
 
@@ -48,10 +48,10 @@ go build -o eat
 - [x] 支持`eat -c 35%`和`eat -m 35%`
 - [x] 支持优雅退出: 捕捉进程 SIGINT, SIGTERM 信号实现有序退出
 - [x] 支持时限: `-t` 限制吃资源的时间，示例 "300ms", "1.5h", "2h45m". (单位: "ns", "us" (or "µs"), "ms", "s", "m", "h")
-- [] CPU亲和性
-- [] 内存读写，防止内存被交换出去
-- [] 动态调整CPU和内存使用
-- [] 吃GPU
+- [ ] CPU亲和性
+- [x] 定期内存读写，防止内存被交换出去
+- [ ] 动态调整CPU和内存使用
+- [ ] 吃GPU
 
 # 使用
 

--- a/cmd/constant.go
+++ b/cmd/constant.go
@@ -8,4 +8,5 @@ const (
 	intervalCpuWorkerCheckContextDone = 10000
 	durationMemoryWorkerDoRefresh     = 5 * time.Minute
 	durationEachSignCheck             = 100 * time.Millisecond
+	chunkSizeMemoryWokerEachAllocate  = 128 * 1024 * 1024 // 128MB
 )

--- a/cmd/constant.go
+++ b/cmd/constant.go
@@ -1,0 +1,11 @@
+package cmd
+
+import (
+	"time"
+)
+
+const (
+	intervalCpuWorkerCheckContextDone = 10000
+	durationMemoryWorkerDoRefresh     = 5 * time.Minute
+	durationEachSignCheck             = 100 * time.Millisecond
+)

--- a/cmd/cpu.go
+++ b/cmd/cpu.go
@@ -10,13 +10,11 @@ import (
 	"time"
 )
 
-const interval = 10000
-
 func busyWork(ctx context.Context) {
 	cnt := 0
 	for {
 		cnt += 1
-		if cnt%interval == 0 {
+		if cnt%intervalCpuWorkerCheckContextDone == 0 {
 			cnt = 0
 			select {
 			case <-ctx.Done():
@@ -38,7 +36,7 @@ func partialBusyWork(ctx context.Context, ratio float64) {
 	//   busy 0.8                     idle 0.19999999999999996
 	//   busyRound 8ms                idleRound 2ms
 	//
-	// case 2: ratio 0.2
+	// case 2: ratio 0.16
 	//   busy 0.16000000000000014     idle 0.8399999999999999
 	//   buseRound 1.6ms              idleRound 8.4ms
 	busyDuration := time.Duration(math.Floor(ratio*precision)) * oneCycle
@@ -49,7 +47,7 @@ func partialBusyWork(ctx context.Context, ratio float64) {
 		busyStart := time.Now()
 		for time.Since(busyStart) < busyDuration {
 			cnt += 1 // Simulate work
-			if cnt%interval == 0 {
+			if cnt%intervalCpuWorkerCheckContextDone == 0 {
 				cnt = 0
 				select {
 				case <-ctx.Done():

--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -1,18 +1,110 @@
 package cmd
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	unimem "github.com/pbnjay/memory"
+	"log"
+	"sync"
+	"time"
 )
 
-func eatMemory(memoryBytes uint64) {
-	if memoryBytes == 0 {
+// ActiveMemoryManager struct to encapsulate buffer and related methods
+type ActiveMemoryManager struct {
+	buffer  []byte
+	size    uint64
+	mu      sync.Mutex
+}
+
+// NewActiveMemoryManager creates a new ActiveMemoryManager
+func NewActiveMemoryManager(size uint64) *ActiveMemoryManager {
+	return &ActiveMemoryManager{size: size}
+}
+
+// AllocateMemory initializes the memory buffer
+func (m *ActiveMemoryManager) AllocateMemory(ctx context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.buffer != nil {
+		return errors.New("allocated, please free it before retry")
+	}
+	curFreeSize := unimem.FreeMemory()
+	if m.size > curFreeSize {
+		return fmt.Errorf("free memory not enough: %d > %d", m.size, curFreeSize)
+	}
+	fmt.Printf("Eating %-12s", "memory...")
+	m.buffer = make([]byte, m.size)
+	for i := range m.buffer {
+		m.buffer[i] = byte(i % 256)
+	}
+	fmt.Printf("Ate %d bytes memory\n", m.size)
+	return nil
+}
+
+// RefreshMemory touches the memory to keep it active
+func (m *ActiveMemoryManager) RefreshMemory() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.buffer == nil {
+		return
+	}
+	for i := range m.buffer {
+		// XOR with 0 keeps the value unchanged but touches the memory
+		m.buffer[i] ^= 0
+	}
+}
+
+// FreeMemory let GC release allocated memory
+func (m *ActiveMemoryManager) FreeMemory() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.buffer == nil {
+		return
+	}
+	m.buffer = nil
+}
+
+func eatMemWork(ctx context.Context, size uint64, refreshInterval time.Duration) {
+	m := NewActiveMemoryManager(size)
+	err := m.AllocateMemory(ctx)
+	if err != nil {
+		log.Printf("failed to allocate memory due to %s\n", err.Error())
 		return
 	}
 
-	memoryBlock := make([]byte, memoryBytes)
-	fmt.Printf("Eating %-12s", "memory...")
-	for i := range memoryBlock {
-		memoryBlock[i] = byte(i % 256)
+	ticker := time.NewTicker(refreshInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			m.RefreshMemory()
+			log.Println("eatMemWork: Memory refreshed to keep it active")
+		case <-ctx.Done():
+			log.Println("eatMemWork: quit due to context being cancelled")
+			m.FreeMemory()
+			log.Println("eatMemWork: Memory freed")
+			return
+		default:
+			time.Sleep(durationEachSignCheck)
+		}
 	}
-	fmt.Printf("Ate %d bytes memory\n", memoryBytes)
+}
+
+func eatMemory(
+	ctx context.Context, wg *sync.WaitGroup,
+	memoryBytes uint64, refreshInterval time.Duration,
+) {
+	if memoryBytes == 0 {
+		return
+	}
+	if refreshInterval <= 0 {
+		refreshInterval = durationMemoryWorkerDoRefresh
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		eatMemWork(ctx, memoryBytes, refreshInterval)
+	}()
 }

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -70,7 +70,7 @@ func parseEatMemoryBytes(m string) uint64 {
 	return 0
 }
 
-func parseEatDeadline(eta string) time.Duration {
+func parseTimeDuration(eta string) time.Duration {
 	duration, err := time.ParseDuration(eta)
 	if err != nil {
 		return time.Duration(0)

--- a/main.go
+++ b/main.go
@@ -14,7 +14,9 @@ func main() {
 	rootCmd.PersistentFlags().StringP("cpu_usage", "c", "0", "How many cpu would you want eat")
 	rootCmd.PersistentFlags().StringP("memory_usage", "m", "0m", "How many memory would you want eat(GB)")
 	// such as "300ms", "1.5h", "2h45m". (unit: "ns", "us" (or "µs"), "ms", "s", "m", "h")
-	rootCmd.PersistentFlags().StringP("time_deadline", "t", "0", "deadline to quit eat process")
+	rootCmd.PersistentFlags().StringP("time_deadline", "t", "0", "Deadline to quit eat process")
+	// same unit as time_deadline
+	rootCmd.PersistentFlags().StringP("memory_refresh_interval", "r", "5m", "How often to trigger a refresh to prevent the ate memory from being swapped out")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Hi Shawn:

## New Feature:

- [x] Memory read/write periodically, prevent memory from being swapped out

```go
for i := range m.buffer {
	// XOR with 0 keeps the value unchanged but refresh the last modified time of memory
	m.buffer[i] ^= 0
}
```

start a goroutine to refresh(`XOR with 0`) the last modified time of every bytes of allocated memory. (a.k.a ActiveMemoryManager)


## Performance Improved:

- [x] Split user-request large memory to multiple small-size chunks(128MB by default)

Because available memory is not equal to contiguously allocatable memory due to memory fragmentation, So directly call `make([]byte, m.size)` with `xxxGB` may fail.

```go
	// split request memory to multiple small-size chunks
	const unitChunk = chunkSizeMemoryWokerEachAllocate
	nChunks := m.size / unitChunk
	remain := m.size % unitChunk
	bufSizes := []uint64{}
	for i := uint64(0); i < nChunks; i++ {
		bufSizes = append(bufSizes, unitChunk)
	}
	if remain > 0 {
		bufSizes = append(bufSizes, remain)
	}

	fmt.Printf("Eating %-12sStart\n", "memory...")
	// Because free memory not equal to contiguous free memory, `make([]byte, m.size)` may fail
	// So we change the direct allocation to "divide and conquer", each time we only allocate small chunk of memory.
	m.buffers = make([][]byte, len(bufSizes))
	for i := range m.buffers {
		select {
		case <-ctx.Done():
			m.buffers = nil
			return errors.New("cancel allocation")
		default:
			//
		}
		curSize := bufSizes[i]
		curFreeSize = unimem.FreeMemory()
		if curSize > curFreeSize {
			m.buffers = nil
			return fmt.Errorf("free memory not enough: %d > %d", curSize, curFreeSize)
		}

		buffer := make([]byte, curSize)
		for i := range buffer {
			buffer[i] = byte(i % 256)
		}
		m.buffers[i] = buffer
	}

	fmt.Printf("Ate %d bytes memory\n", m.size)
```

Thanks for your review.