### PR TITLE
Feat support cpu affinity for eat in linux

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.22'
 
       - name: Build
         run: go build -v ./...

--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ Developer will encounter the need to quickly occupy CPU and memory, I am also de
 - [x] Support `eat -c 35%` and `eat -m 35%`
 - [x] support gracefully exit: capture process signal SIGINT(2), SIGTERM(15)
 - [x] support deadline: `-t` specify the duration of eat progress. such as "300ms", "1.5h", "2h45m". (unit: "ns", "us" (or "µs"), "ms", "s", "m", "h")
-- [ ] CPU Affinity
+- [x] CPU Affinity
+  - [x] Linux
+  - [ ] macOs
+  - [ ] Windows
 - [x] Memory read/write periodically , prevent memory from being swapped out
 - [ ] Dynamic adjustment of CPU and memory usage
 - [ ] Eat GPU
@@ -16,17 +19,42 @@ Developer will encounter the need to quickly occupy CPU and memory, I am also de
 # Usage
 
 ```shell
-eat -c 4            # eating 4 CPU core
-eat -c 35%          # eating 35% CPU core (CPU count * 35%)
-eat -c 100%         # eating all CPU core
-eat -m 4g           # eating 4GB memory
-eat -m 20m          # eating 20MB memory
-eat -m 35%          # eating 35% memory (total memory * 35%)
-eat -m 100%         # eating all memory
-eat -c 2.5 -m 1.5g  # eating 2.5 CPU core and 1.5GB memory
-eat -c 3 -m 200m    # eating 3 CPU core and 200MB memory
-eat -c 100% -m 100% # eating all CPU core and memory
-eat -c 100% -t 1h # eating all CPU core and quit after 1hour
+$ ./eat.out --help
+A monster that eats cpu and memory 🦕
+
+Usage:
+    eat [flags]
+
+Flags:
+  --cpu-affinities ints                  Which cpu core(s) would you want to eat? multiple cores separate by ','
+  -c, --cpu-usage string                 How many cpu would you want eat (default "0")
+  -h, --help                             help for eat
+  -r, --memory-refresh-interval string   How often to trigger a refresh to prevent the ate memory from being swapped out (default "5m")
+  -m, --memory-usage string              How many memory would you want eat(GB) (default "0m")
+  -t, --time-deadline string             Deadline to quit eat process (default "0")
+```
+
+```shell
+eat -c 4										# eating 4 CPU core
+eat -c 35%										# eating 35% CPU core (CPU count * 35%)
+eat -c 100%										# eating all CPU core
+eat -m 4g										# eating 4GB memory
+eat -m 20m										# eating 20MB memory
+eat -m 35%										# eating 35% memory (total memory * 35%)
+eat -m 100%										# eating all memory
+eat -c 2.5 -m 1.5g								# eating 2.5 CPU core and 1.5GB memory
+eat -c 3 -m 200m								# eating 3 CPU core and 200MB memory
+eat -c 100% -m 100%								# eating all CPU core and memory
+eat -c 100% -t 1h								# eating all CPU core and quit after 1hour
+
+eat --cpu-affinities 0 -c 1						# only run eat in core #0 (first core)
+eat --cpu-affinities 0,1 -c 2					# run eat in core #0,1 (first and second core)
+eat --cpu-affinities 0,1,2,3 -c 100% 			# error case: in-enough cpu affinities
+# Have 8C15G.
+# Error: failed to parse cpu affinities, reason: each request cpu cores need specify its affinity, aff 4 < req 8
+eat --cpu-affinities 0,1,2,3 -c 50%				# run eat in core #0,1,2,3 (first to fourth core)
+eat --cpu-affinities 0,1,2,3,4,5,6,7 -c 92% 	# run eat in all core(full of 7 cores, part of last core)
+
 ```
 
 > Tips:
@@ -35,11 +63,16 @@ eat -c 100% -t 1h # eating all CPU core and quit after 1hour
 # Build
 
 ```shell
-go build -o eat
+# Linux
+GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat
+# macOs
+GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat_mac
+# Windows
+GOOS=windwos GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat_win
 ```
 
 # 介绍
-<b>我是一个吃CPU和内存的怪兽🦕</b>
+<b>我是一只吃CPU和内存的怪兽🦕</b>
 
 开发者们经常会遇到需要快速占用 CPU 和内存的需求，我也是。所以我开发了一个名为 `eat` 的小工具来快速占用指定数量的 CPU 和内存。
 
@@ -48,25 +81,54 @@ go build -o eat
 - [x] 支持`eat -c 35%`和`eat -m 35%`
 - [x] 支持优雅退出: 捕捉进程 SIGINT, SIGTERM 信号实现有序退出
 - [x] 支持时限: `-t` 限制吃资源的时间，示例 "300ms", "1.5h", "2h45m". (单位: "ns", "us" (or "µs"), "ms", "s", "m", "h")
-- [ ] CPU亲和性
+- [x] CPU亲和性
+  - [X] Linux 
+  - [ ] macOS
+  - [ ] Windows
 - [x] 定期内存读写，防止内存被交换出去
 - [ ] 动态调整CPU和内存使用
 - [ ] 吃GPU
 
 # 使用
 
+
 ```shell
-eat -c 4            # 占用4个CPU核
-eat -c 35%          # 占用35%CPU核（CPU核数 * 35%）
-eat -c 100%         # 占用所有CPU核
-eat -m 4g           # 占用4GB内存
-eat -m 20m          # 占用20MB内存
-eat -m 35%          # 占用35%内存（总内存 * 35%）
-eat -m 100%         # 占用所有内存
-eat -c 2.5 -m 1.5g  # 占用2.5个CPU核和1.5GB内存
-eat -c 3 -m 200m    # 占用3个CPU核和200MB内存
-eat -c 100% -m 100% # 占用所有CPU核和内存
-eat -c 100% -t 1h   # 占用所有CPU核并在一小时后退出
+$ ./eat.out --help
+我是一只吃CPU和内存的怪兽🦕
+
+使用方法
+    eat [flags］
+
+Flags：
+  --cpu-affinities 整数						指定在几个核心上运行 Eat，多个核心索引之间用 ',' 分隔，索引从 0 开始。
+  -c, --cpu-usage 字符串						你想吃掉多少个 CPU（默认为 '0'）？
+  -h，--help								输出 eat 的帮助
+  -r, --memory-refresh-interval 字符串		每隔多长时间触发一次刷新，以防止被吃掉的内存被交换出去（默认值为 '5m'）
+  -m, --memory-usage 字符串					你希望吃掉多少内存（GB）（默认值 '0m'）
+  -t，--time-deadline 字符串					退出 eat 进程的截止日期（默认为 "0'）。
+```
+
+```shell
+eat -c 4									# 占用4个CPU核
+eat -c 35%									# 占用35%CPU核（CPU核数 * 35%）
+eat -c 100%									# 占用所有CPU核
+eat -m 4g									# 占用4GB内存
+eat -m 20m									# 占用20MB内存
+eat -m 35%									# 占用35%内存（总内存 * 35%）
+eat -m 100%									# 占用所有内存
+eat -c 2.5 -m 1.5g							# 占用2.5个CPU核和1.5GB内存
+eat -c 3 -m 200m							# 占用3个CPU核和200MB内存
+eat -c 100% -m 100%							# 占用所有CPU核和内存
+eat -c 100% -t 1h							# 占用所有CPU核并在一小时后退出
+
+eat --cpu-affinities 0 -c 1					# 只占用 #0 第一个核心
+eat --cpu-affinities 0,1 -c 2				# 占用 #0,1 前两个个核心
+eat --cpu-affinities 0,1,2,3 -c 100% 		# 错误参数: 每个请求核都要指定对应的亲和性核心
+# Have 8C15G.
+# Error: failed to parse cpu affinities, reason: each request cpu cores need specify its affinity, aff 4 < phy 8
+# 出错: 无法解析 CPU 亲和性, 原因: 每个请求核都要指定对应的亲和性核心, 亲和核  4 < 请求核 8
+eat --cpu-affinities 0,1,2,3 -c 50%			# 占用前4个核心
+eat --cpu-affinities 0,1,2,3,4,5,6,7 -c 92%	# 占用前8个核心 (全部7个核心，部分的最后一个核心)
 ```
 
 > 提示：
@@ -75,5 +137,10 @@ eat -c 100% -t 1h   # 占用所有CPU核并在一小时后退出
 # 构建
 
 ```shell
-go build -o eat
+# Linux
+GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat
+# macOs
+GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat_mac
+# Windows
+GOOS=windwos GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat_win
 ```

--- a/cmd/constant.go
+++ b/cmd/constant.go
@@ -1,12 +1,28 @@
 package cmd
 
 import (
+	"fmt"
 	"time"
 )
+
+// contextKey is a value for use with context.WithValue.
+// It's used as a pointer. so it fits in an interface{} without allocation.
+type contextKey struct {
+	name      string
+	valueType string
+}
+
+func (k *contextKey) String() string {
+	return fmt.Sprintf("worker context value: name %s, type %s", k.name, k.valueType)
+}
 
 const (
 	intervalCpuWorkerCheckContextDone = 10000
 	durationMemoryWorkerDoRefresh     = 5 * time.Minute
 	durationEachSignCheck             = 100 * time.Millisecond
 	chunkSizeMemoryWorkerEachAllocate = 128 * 1024 * 1024 // 128MB
+)
+
+var (
+	cpuWorkerPartialCoreRatioContextKey = &contextKey{"partialCoreRatio", "float64"}
 )

--- a/cmd/cpu.go
+++ b/cmd/cpu.go
@@ -103,7 +103,7 @@ func setCpuAffWrapper(index int, cpuAffinitiesEat []uint) (func(), error) {
 	// A goroutine should **call LockOSThread before** calling OS services or non-Go library functions
 	// that depend on per-thread state.
 	runtime.LockOSThread() // IMPORTANT!! Only limit the system thread affinity, not the whole go program process
-	var cpuAffDeputy cpu_affinity.CpuAffinitySysCall = cpu_affinity.CpuAffinityDeputy{}
+	var cpuAffDeputy = cpu_affinity.NewCpuAffinityDeputy()
 	if !cpuAffDeputy.IsImplemented() {
 		return nil, fmt.Errorf("SetCpuAffinities currently not support in this os: %s", runtime.GOOS)
 	}

--- a/cmd/cpu_affinity/cpu_affinity_linux.go
+++ b/cmd/cpu_affinity/cpu_affinity_linux.go
@@ -4,120 +4,11 @@
 package cpu_affinity
 
 import (
-	"math/bits"
 	"runtime"
 	"syscall"
-	"unsafe"
+
+	"golang.org/x/sys/unix"
 )
-
-const (
-	cpuSetSize = 0x400
-	nCpuBits   = 0x40
-	cpuSetLen  = cpuSetSize / nCpuBits
-)
-
-type cpuMaskT uint64
-
-// cpuSet use array to represents a CPU affinity mask.
-type cpuSet [cpuSetLen]cpuMaskT
-
-const (
-	enoAGAIN = syscall.Errno(0xb)
-	enoINVAL = syscall.Errno(0x16)
-	enoNOENT = syscall.Errno(0x2)
-)
-
-// Do the interface allocations only once for common
-// Errno values.
-var (
-	errEAGAIN error = syscall.EAGAIN
-	errEINVAL error = syscall.EINVAL
-	errENOENT error = syscall.ENOENT
-)
-
-// errnoErr returns common boxed Errno values, to prevent allocations at runtime.
-func errnoErr(e syscall.Errno) error {
-	switch e {
-	case 0:
-		return nil
-	case enoAGAIN:
-		return errEAGAIN
-	case enoINVAL:
-		return errEINVAL
-	case enoNOENT:
-		return errENOENT
-	}
-	return e
-}
-
-func schedAffinity(trap uintptr, pid uint, set *cpuSet) error {
-	_, _, e := syscall.RawSyscall(trap, uintptr(pid), unsafe.Sizeof(*set), uintptr(unsafe.Pointer(set)))
-	if e != 0 {
-		return errnoErr(e)
-	}
-	return nil
-}
-
-// schedGetAffinity gets the CPU affinity mask of the thread specified by pid.
-// If pid is 0 the calling thread is used.
-func schedGetAffinity(pid uint, set *cpuSet) error {
-	return schedAffinity(syscall.SYS_SCHED_GETAFFINITY, pid, set)
-}
-
-// schedSetAffinity sets the CPU affinity mask of the thread specified by pid.
-// If pid is 0 the calling thread is used.
-func schedSetAffinity(pid uint, set *cpuSet) error {
-	return schedAffinity(syscall.SYS_SCHED_SETAFFINITY, pid, set)
-}
-
-// Zero clears the set s, so that it contains no CPUs.
-func (s *cpuSet) Zero() {
-	for i := range s {
-		s[i] = 0
-	}
-}
-
-func cpuBitsIndex(cpu uint) uint {
-	return cpu / nCpuBits
-}
-
-func cpuBitsMask(cpu uint) cpuMaskT {
-	return cpuMaskT(1 << (uint(cpu) % nCpuBits))
-}
-
-// Set adds cpu to the set s.
-func (s *cpuSet) Set(cpu uint) {
-	i := cpuBitsIndex(cpu)
-	if int(i) < len(s) {
-		s[i] |= cpuBitsMask(cpu)
-	}
-}
-
-// Clear removes cpu from the set s.
-func (s *cpuSet) Clear(cpu uint) {
-	i := cpuBitsIndex(cpu)
-	if int(i) < len(s) {
-		s[i] &^= cpuBitsMask(cpu)
-	}
-}
-
-// IsSet reports whether cpu is in the set s.
-func (s *cpuSet) IsSet(cpu uint) bool {
-	i := cpuBitsIndex(cpu)
-	if int(i) < len(s) {
-		return s[i]&cpuBitsMask(cpu) != 0
-	}
-	return false
-}
-
-// Count returns the number of CPUs in the set s.
-func (s *cpuSet) Count() uint {
-	var c uint = 0
-	for _, b := range s {
-		c += uint(bits.OnesCount64(uint64(b)))
-	}
-	return c
-}
 
 type CpuAffinityDeputy struct{}
 
@@ -133,24 +24,24 @@ func (CpuAffinityDeputy) SetCpuAffinities(pid uint, cpus ...uint) error {
 	if len(cpus) == 0 {
 		return nil
 	}
-	mask := new(cpuSet)
+	mask := new(unix.CPUSet)
 	mask.Zero()
 	for _, c := range cpus {
-		mask.Set(c)
+		mask.Set(int(c))
 	}
-	return schedSetAffinity(pid, mask)
+	return unix.SchedSetaffinity(int(pid), mask)
 }
 
 func (CpuAffinityDeputy) GetCpuAffinities(pid uint) (map[uint]bool, error) {
-	mask := new(cpuSet)
+	mask := new(unix.CPUSet)
 	mask.Zero()
-	err := schedGetAffinity(pid, mask)
+	err := unix.SchedGetaffinity(int(pid), mask)
 	if err != nil {
 		return nil, err
 	}
 	var res = make(map[uint]bool)
 	for i := 0; i < runtime.NumCPU(); i++ {
-		res[uint(i)] = mask.IsSet(uint(i))
+		res[uint(i)] = mask.IsSet(i)
 	}
 	return res, nil
 }

--- a/cmd/cpu_affinity/cpu_affinity_linux.go
+++ b/cmd/cpu_affinity/cpu_affinity_linux.go
@@ -1,0 +1,160 @@
+//go:build linux
+// +build linux
+
+package cpu_affinity
+
+import (
+	"math/bits"
+	"runtime"
+	"syscall"
+	"unsafe"
+)
+
+const (
+	cpuSetSize = 0x400
+	nCpuBits   = 0x40
+	cpuSetLen  = cpuSetSize / nCpuBits
+)
+
+type cpuMaskT uint64
+
+// cpuSet use array to represents a CPU affinity mask.
+type cpuSet [cpuSetLen]cpuMaskT
+
+const (
+	enoAGAIN = syscall.Errno(0xb)
+	enoINVAL = syscall.Errno(0x16)
+	enoNOENT = syscall.Errno(0x2)
+)
+
+// Do the interface allocations only once for common
+// Errno values.
+var (
+	errEAGAIN error = syscall.EAGAIN
+	errEINVAL error = syscall.EINVAL
+	errENOENT error = syscall.ENOENT
+)
+
+// errnoErr returns common boxed Errno values, to prevent allocations at runtime.
+func errnoErr(e syscall.Errno) error {
+	switch e {
+	case 0:
+		return nil
+	case enoAGAIN:
+		return errEAGAIN
+	case enoINVAL:
+		return errEINVAL
+	case enoNOENT:
+		return errENOENT
+	}
+	return e
+}
+
+func schedAffinity(trap uintptr, pid uint, set *cpuSet) error {
+	_, _, e := syscall.RawSyscall(trap, uintptr(pid), unsafe.Sizeof(*set), uintptr(unsafe.Pointer(set)))
+	if e != 0 {
+		return errnoErr(e)
+	}
+	return nil
+}
+
+// schedGetAffinity gets the CPU affinity mask of the thread specified by pid.
+// If pid is 0 the calling thread is used.
+func schedGetAffinity(pid uint, set *cpuSet) error {
+	return schedAffinity(syscall.SYS_SCHED_GETAFFINITY, pid, set)
+}
+
+// schedSetAffinity sets the CPU affinity mask of the thread specified by pid.
+// If pid is 0 the calling thread is used.
+func schedSetAffinity(pid uint, set *cpuSet) error {
+	return schedAffinity(syscall.SYS_SCHED_SETAFFINITY, pid, set)
+}
+
+// Zero clears the set s, so that it contains no CPUs.
+func (s *cpuSet) Zero() {
+	for i := range s {
+		s[i] = 0
+	}
+}
+
+func cpuBitsIndex(cpu uint) uint {
+	return cpu / nCpuBits
+}
+
+func cpuBitsMask(cpu uint) cpuMaskT {
+	return cpuMaskT(1 << (uint(cpu) % nCpuBits))
+}
+
+// Set adds cpu to the set s.
+func (s *cpuSet) Set(cpu uint) {
+	i := cpuBitsIndex(cpu)
+	if int(i) < len(s) {
+		s[i] |= cpuBitsMask(cpu)
+	}
+}
+
+// Clear removes cpu from the set s.
+func (s *cpuSet) Clear(cpu uint) {
+	i := cpuBitsIndex(cpu)
+	if int(i) < len(s) {
+		s[i] &^= cpuBitsMask(cpu)
+	}
+}
+
+// IsSet reports whether cpu is in the set s.
+func (s *cpuSet) IsSet(cpu uint) bool {
+	i := cpuBitsIndex(cpu)
+	if int(i) < len(s) {
+		return s[i]&cpuBitsMask(cpu) != 0
+	}
+	return false
+}
+
+// Count returns the number of CPUs in the set s.
+func (s *cpuSet) Count() uint {
+	var c uint = 0
+	for _, b := range s {
+		c += uint(bits.OnesCount64(uint64(b)))
+	}
+	return c
+}
+
+type CpuAffinityDeputy struct{}
+
+func (CpuAffinityDeputy) GetProcessId() uint {
+	return uint(syscall.Getpid())
+}
+
+func (CpuAffinityDeputy) GetThreadId() uint {
+	return uint(syscall.Gettid())
+}
+
+func (CpuAffinityDeputy) SetCpuAffinities(pid uint, cpus ...uint) error {
+	if len(cpus) == 0 {
+		return nil
+	}
+	mask := new(cpuSet)
+	mask.Zero()
+	for _, c := range cpus {
+		mask.Set(c)
+	}
+	return schedSetAffinity(pid, mask)
+}
+
+func (CpuAffinityDeputy) GetCpuAffinities(pid uint) (map[uint]bool, error) {
+	mask := new(cpuSet)
+	mask.Zero()
+	err := schedGetAffinity(pid, mask)
+	if err != nil {
+		return nil, err
+	}
+	var res = make(map[uint]bool)
+	for i := 0; i < runtime.NumCPU(); i++ {
+		res[uint(i)] = mask.IsSet(uint(i))
+	}
+	return res, nil
+}
+
+func (CpuAffinityDeputy) IsImplemented() bool {
+	return true
+}

--- a/cmd/cpu_affinity/cpu_affinity_linux_test.go
+++ b/cmd/cpu_affinity/cpu_affinity_linux_test.go
@@ -10,6 +10,8 @@ import (
 	"runtime"
 	"slices"
 	"testing"
+
+	"golang.org/x/sys/unix"
 )
 
 func TestSchedGetAffinity(t *testing.T) {
@@ -57,9 +59,14 @@ func genRandomCpuCore(num int) []uint {
 
 func TestSchedSetAffinity(t *testing.T) {
 	pid := os.Getpid()
-	mask := new(cpuSet)
+	mask := new(unix.CPUSet)
 	mask.Zero()
-	modCpuCores := genRandomCpuCore(2)
+	var modCpuCores []uint
+	if runtime.NumCPU() > 2 {
+		modCpuCores = genRandomCpuCore(2)
+	} else {
+		modCpuCores = []uint{0}
+	}
 	cpuAffDeputy := CpuAffinityDeputy{}
 	err := cpuAffDeputy.SetCpuAffinities(uint(pid), modCpuCores...)
 	if err != nil {
@@ -83,6 +90,5 @@ func TestSchedSetAffinity(t *testing.T) {
 		if expect != val {
 			t.Errorf("cpu %d affinities not equal expect: %v", i, expect)
 		}
-
 	}
 }

--- a/cmd/cpu_affinity/cpu_affinity_linux_test.go
+++ b/cmd/cpu_affinity/cpu_affinity_linux_test.go
@@ -1,0 +1,88 @@
+//go:build linux
+// +build linux
+
+package cpu_affinity
+
+import (
+	"math"
+	"math/rand"
+	"os"
+	"runtime"
+	"slices"
+	"testing"
+)
+
+func TestSchedGetAffinity(t *testing.T) {
+	pid := os.Getpid()
+	cpuAffDeputy := CpuAffinityDeputy{}
+	res, err := cpuAffDeputy.GetCpuAffinities(uint(pid))
+	if err != nil {
+		t.Errorf("schedGetAffinity failed: %v", err)
+		return
+	}
+	var firstMask bool
+	for i := 0; i < runtime.NumCPU(); i++ {
+		val, ok := res[uint(i)]
+		if !ok {
+			t.Errorf("core index %d not found in GetCpuAffinities result", i)
+			return
+		}
+		if i == 0 {
+			firstMask = val
+			continue
+		}
+
+		// it should be all true or all false
+		if firstMask != val {
+			t.Errorf("cpu %d mask should be %v(not set), but it is %v", i, firstMask, !firstMask)
+		}
+	}
+}
+
+func genRandomCpuCore(num int) []uint {
+	numCpu := runtime.NumCPU()
+	if num > (numCpu - 1) {
+		num = numCpu - 1
+	}
+	var uniqueCores []uint
+	for len(uniqueCores) != num {
+		core := uint(math.Floor(rand.Float64() * float64(numCpu)))
+		if slices.Contains(uniqueCores, core) {
+			continue
+		}
+		uniqueCores = append(uniqueCores, core)
+	}
+	return uniqueCores
+}
+
+func TestSchedSetAffinity(t *testing.T) {
+	pid := os.Getpid()
+	mask := new(cpuSet)
+	mask.Zero()
+	modCpuCores := genRandomCpuCore(2)
+	cpuAffDeputy := CpuAffinityDeputy{}
+	err := cpuAffDeputy.SetCpuAffinities(uint(pid), modCpuCores...)
+	if err != nil {
+		t.Errorf("SetCpuAffinities failed: %v", err)
+		return
+	}
+
+	resMap, errGet := cpuAffDeputy.GetCpuAffinities(uint(pid))
+	if errGet != nil {
+		t.Errorf("schedGetAffinity failed: %v", errGet)
+		return
+	}
+
+	for i := 0; i < runtime.NumCPU(); i++ {
+		expect := slices.Contains(modCpuCores, uint(i))
+		val, ok := resMap[uint(i)]
+		if !ok {
+			t.Errorf("core index %d not found in GetCpuAffinities result", i)
+			return
+		}
+		if expect != val {
+			t.Errorf("cpu %d affinities not equal expect: %v", i, expect)
+		}
+
+	}
+}

--- a/cmd/cpu_affinity/cpu_affinity_other.go
+++ b/cmd/cpu_affinity/cpu_affinity_other.go
@@ -1,0 +1,31 @@
+//go:build !linux
+// +build !linux
+
+package cpu_affinity
+
+import (
+	"fmt"
+	"runtime"
+)
+
+type CpuAffinityDeputy struct{}
+
+func (CpuAffinityDeputy) GetProcessId() uint {
+	return 0
+}
+
+func (CpuAffinityDeputy) GetThreadId() uint {
+	return 0
+}
+
+func (CpuAffinityDeputy) SetCpuAffinities(pid uint, cpus ...uint) error {
+	return fmt.Errorf("SetCpuAffinities currently not support in this os: %s", runtime.GOOS)
+}
+
+func (CpuAffinityDeputy) GetCpuAffinities(pid uint) (map[uint]bool, error) {
+	return nil, fmt.Errorf("GetCpuAffinities currently not support in this os: %s", runtime.GOOS)
+}
+
+func (CpuAffinityDeputy) IsImplemented() bool {
+	return false
+}

--- a/cmd/cpu_affinity/os_shared.go
+++ b/cmd/cpu_affinity/os_shared.go
@@ -7,3 +7,7 @@ type CpuAffinitySysCall interface {
 	SetCpuAffinities(pid uint, cpus ...uint) error
 	GetCpuAffinities(pid uint) (map[uint]bool, error)
 }
+
+func NewCpuAffinityDeputy() CpuAffinitySysCall {
+	return CpuAffinityDeputy{}
+}

--- a/cmd/cpu_affinity/os_shared.go
+++ b/cmd/cpu_affinity/os_shared.go
@@ -1,0 +1,9 @@
+package cpu_affinity
+
+type CpuAffinitySysCall interface {
+	GetProcessId() uint
+	GetThreadId() uint
+	IsImplemented() bool
+	SetCpuAffinities(pid uint, cpus ...uint) error
+	GetCpuAffinities(pid uint) (map[uint]bool, error)
+}

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -88,7 +88,7 @@ func parseCpuAffinity(affCores []int, needCores float64) ([]uint, error) {
 	if len(affCores) == 0 { // user don't set cpu affinity, skip
 		return nil, nil
 	}
-	var cpuAffDeputy cpu_affinity.CpuAffinitySysCall = cpu_affinity.CpuAffinityDeputy{}
+	var cpuAffDeputy = cpu_affinity.NewCpuAffinityDeputy()
 	if !cpuAffDeputy.IsImplemented() {
 		return nil, fmt.Errorf("SetCpuAffinities currently not support in this os: %s", runtime.GOOS)
 	}

--- a/cmd/parse.go
+++ b/cmd/parse.go
@@ -2,10 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"math"
 	"runtime"
 	"strconv"
 	"time"
 
+	"eat/cmd/cpu_affinity"
 	"github.com/pbnjay/memory"
 )
 
@@ -79,4 +81,34 @@ func parseTimeDuration(eta string) time.Duration {
 		return time.Duration(0)
 	}
 	return duration
+}
+
+// parseCpuAffinity validate cpu cores and check it cover request cores
+func parseCpuAffinity(affCores []int, needCores float64) ([]uint, error) {
+	if len(affCores) == 0 { // user don't set cpu affinity, skip
+		return nil, nil
+	}
+	var cpuAffDeputy cpu_affinity.CpuAffinitySysCall = cpu_affinity.CpuAffinityDeputy{}
+	if !cpuAffDeputy.IsImplemented() {
+		return nil, fmt.Errorf("SetCpuAffinities currently not support in this os: %s", runtime.GOOS)
+	}
+	numCpu := runtime.NumCPU()
+	var validCpuAffList []uint
+	for _, cpu := range affCores {
+		if cpu < 0 {
+			continue
+		}
+		if cpu >= numCpu {
+			continue
+		}
+		validCpuAffList = append(validCpuAffList, uint(cpu))
+	}
+	fullCores := int(math.Ceil(needCores))
+	if len(validCpuAffList) < fullCores {
+		return nil, fmt.Errorf(
+			"each request cpu cores need specify its affinity, aff %d < req %d",
+			len(validCpuAffList), fullCores,
+		)
+	}
+	return validCpuAffList, nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -70,8 +70,7 @@ func getRootContext(dlEat time.Duration) (context.Context, context.CancelFunc) {
 		deadline := time.Now().Add(dlEat)
 		rootCtx, cancel = context.WithDeadline(context.Background(), deadline)
 	} else {
-		rootCtx = context.Background()
-		cancel = func() {}
+		rootCtx, cancel = context.WithCancel(context.Background())
 	}
 	return rootCtx, cancel
 }
@@ -103,7 +102,7 @@ func eatFunction(cmd *cobra.Command, _ []string) {
 	eatMemory(rootCtx, &wg, mEat, mAteRenew)
 	eatCPU(rootCtx, &wg, cEat)
 	// in case that all sub goroutines are dead due to runtime error like memory not enough.
-	// so the main gooutine automaticlly quit as well, don't wait user ctrl+c or context deadline.
+	// so the main goroutine automatically quit as well, don't wait user ctrl+c or context deadline.
 	go func(wgp *sync.WaitGroup) {
 		wgp.Wait()
 		cancel()

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module eat
 
-go 1.20
+go 1.22
 
 require (
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58
 	github.com/spf13/cobra v1.8.1
+	golang.org/x/sys v0.22.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -8,5 +8,7 @@ github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
+golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -11,12 +11,13 @@ func main() {
 	rootCmd := cmd.RootCmd
 
 	// Add global flags
-	rootCmd.PersistentFlags().StringP("cpu_usage", "c", "0", "How many cpu would you want eat")
-	rootCmd.PersistentFlags().StringP("memory_usage", "m", "0m", "How many memory would you want eat(GB)")
+	rootCmd.PersistentFlags().StringP("cpu-usage", "c", "0", "How many cpu would you want eat")
+	rootCmd.PersistentFlags().IntSlice("cpu-affinities", []int{}, "Which cpu core(s) would you want to eat? multiple cores separate by ',' (start from 0)")
+	rootCmd.PersistentFlags().StringP("memory-usage", "m", "0m", "How many memory would you want eat(GB)")
 	// such as "300ms", "1.5h", "2h45m". (unit: "ns", "us" (or "µs"), "ms", "s", "m", "h")
-	rootCmd.PersistentFlags().StringP("time_deadline", "t", "0", "Deadline to quit eat process")
-	// same unit as time_deadline
-	rootCmd.PersistentFlags().StringP("memory_refresh_interval", "r", "5m", "How often to trigger a refresh to prevent the ate memory from being swapped out")
+	rootCmd.PersistentFlags().StringP("time-deadline", "t", "0", "Deadline to quit eat process")
+	// same unit as time-deadline
+	rootCmd.PersistentFlags().StringP("memory-refresh-interval", "r", "5m", "How often to trigger a refresh to prevent the ate memory from being swapped out")
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)


### PR DESCRIPTION
Hi Shawn,

## 1 New Feature:
- [x] Specify CPU Affinities for eat program process in Linux (Other systems still Work In Progress. As far as I know, Windows and macOS will share same Interface with Linux) 

Resolved #1  Close #1 

## 2 Introduce

> Processor affinity, or CPU pinning or "cache affinity", **enables the binding and unbinding of a process or a thread to a central processing unit (CPU) or a range of CPUs**, so that the process or thread will *execute only* on the designated CPU or CPUs rather than any CPU.


### 3 Usage

#### 3.1 One Full Core

Only run on first CPU Core `#0`

```shell
eat --cpu-affinities 0 -c 1
```

![Screenshot from 2024-07-09 14-35-19](https://github.com/shawn-bluce/eat/assets/5007859/14f68061-5d8d-439d-9a01-9903a81e410d)

#### 3.2 Multiple Full Cores


```shell
eat --cpu-affinities 0,1,2,3 -c 50%
```

![Screenshot from 2024-07-09 14-36-09](https://github.com/shawn-bluce/eat/assets/5007859/94e95491-cb20-48cb-9403-6519970160ed)


Only run on CPU Core `#4,5,6`. 

> Notice `#7` cpu affinity was declared, but not actually used by eat process. 


```shell
eat --cpu-affinities 4,5,6,7 -c 3
```


![Screenshot from 2024-07-09 14-31-48](https://github.com/shawn-bluce/eat/assets/5007859/bc562e0d-c8a7-42f4-a27f-a505a965faa0)

#### 3.3 Some Full Cores, One Part Core

```shell
// 8 cores * 0.92 = 7.36 cores ~= 7 full cores, 1 part core
eat --cpu-affinities 0,1,2,3,4,5,6,7 -c 92%
```

![Screenshot from 2024-07-09 15-04-24](https://github.com/shawn-bluce/eat/assets/5007859/8cf50f98-59bd-4b0c-b8cb-1c7023cc8665)

Thanks for you review 🤩 