### PR TITLE
Build makefile to cross-compile eat for all os architures

### DIFF
--- a/.github/gen_release_note_from_commits.sh
+++ b/.github/gen_release_note_from_commits.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+while getopts "v:" opt; do
+  case $opt in
+    v)
+      version_range=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [ -z "$version_range" ]; then
+  echo "Please provide the version range using -v option. Example: ./gen_release_note_from_commits.sh -v v1.14.1...v1.14.2"
+  exit 1
+fi
+
+echo "## What's Changed" > release.md
+git log --pretty=format:"* %h %s by @%an" --grep="^feat" -i $version_range | sort -f | uniq >> release.md
+echo "" >> release.md
+
+echo "## BUG & Fix" >> release.md
+git log --pretty=format:"* %h %s by @%an" --grep="^fix" -i $version_range | sort -f | uniq >> release.md
+echo "" >> release.md
+
+echo "## Maintenance" >> release.md
+git log --pretty=format:"* %h %s by @%an" --grep="^chore\|^docs\|^refactor" -i $version_range | sort -f | uniq >> release.md
+echo "" >> release.md
+
+echo "**Full Changelog**: https://github.com/shawn-bluce/eat/compare/$version_range" >> release.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,204 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Tag version to release"
+        required: true
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        jobs:
+          - { goos: darwin, goarch: arm64, output: arm64, test: test }
+          - { goos: darwin, goarch: amd64, goamd64: v1, output: amd64-compatible }
+          - { goos: darwin, goarch: amd64, goamd64: v3, output: amd64, test: test }
+
+          - { goos: linux, goarch: '386', output: '386' }
+          - { goos: linux, goarch: amd64, goamd64: v1, output: amd64-compatible }
+          - { goos: linux, goarch: amd64, goamd64: v3, output: amd64, test: test }
+          - { goos: linux, goarch: arm64, output: arm64, test: test }
+          - { goos: linux, goarch: arm, goarm: '5', output: armv5 }
+          - { goos: linux, goarch: arm, goarm: '6', output: armv6 }
+          - { goos: linux, goarch: arm, goarm: '7', output: armv7 }
+          - { goos: linux, goarch: mips, mips: hardfloat, output: mips-hardfloat }
+          - { goos: linux, goarch: mips, mips: softfloat, output: mips-softfloat }
+          - { goos: linux, goarch: mipsle, mips: hardfloat, output: mipsle-hardfloat }
+          - { goos: linux, goarch: mipsle, mips: softfloat, output: mipsle-softfloat }
+          - { goos: linux, goarch: mips64, output: mips64 }
+          - { goos: linux, goarch: mips64le, output: mips64le }
+          - { goos: linux, goarch: loong64, output: loong64-abi1, abi: '1' }
+          - { goos: linux, goarch: loong64, output: loong64-abi2, abi: '2' }
+          - { goos: linux, goarch: riscv64, output: riscv64 }
+          - { goos: linux, goarch: s390x, output: s390x }
+
+          - { goos: windows, goarch: '386', output: '386' }
+          - { goos: windows, goarch: amd64, goamd64: v1, output: amd64-compatible }
+          - { goos: windows, goarch: amd64, goamd64: v3, output: amd64, test: test }
+          - { goos: windows, goarch: arm, goarm: '7', output: armv7 }
+          - { goos: windows, goarch: arm64, output: arm64, test: test }
+
+          - { goos: freebsd, goarch: '386', output: '386' }
+          - { goos: freebsd, goarch: amd64, goamd64: v1, output: amd64-compatible }
+          - { goos: freebsd, goarch: amd64, goamd64: v3, output: amd64 }
+          - { goos: freebsd, goarch: arm64, output: arm64 }
+
+          - { goos: android, goarch: '386', ndk: i686-linux-android34, output: '386' }
+          - { goos: android, goarch: amd64, ndk: x86_64-linux-android34, output: amd64 }
+          - { goos: android, goarch: arm, ndk: armv7a-linux-androideabi34, output: armv7 }
+          - { goos: android, goarch: arm64, ndk: aarch64-linux-android34, output: arm64-v8 }
+
+    steps:
+      -
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      -
+        name: Set up Go
+        if: ${{ matrix.jobs.goversion == '' }}
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      -
+        name: Set up Go (custom)
+        if: ${{ matrix.jobs.goversion != ''}}
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.jobs.goversion }}
+
+      -
+        name: Set variables
+        if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version != '' }}
+        run: echo "VERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+        shell: bash
+
+      -
+        name: Set Runtime Variable
+        run: |
+          echo "BUILDTIME=$(date)" >> $GITHUB_ENV
+          echo "CGO_ENABLED=0" >> $GITHUB_ENV
+          echo "BUILDHASH=$(git rev-parse HEAD)" >> $GITHUB_ENV
+          echo "BUILDTAG=-extldflags --static" >> $GITHUB_ENV
+
+      -
+        name: Setup NDK
+        if: ${{ matrix.jobs.goos == 'android' }}
+        uses: nttld/setup-ndk@v1
+        id: setup-ndk
+        with:
+          ndk-version: r26c
+
+      -
+        name: Set NDK path
+        if: ${{ matrix.jobs.goos == 'android' }}
+        run: |
+          echo "CC=${{steps.setup-ndk.outputs.ndk-path}}/toolchains/llvm/prebuilt/linux-x86_64/bin/${{matrix.jobs.ndk}}-clang" >> $GITHUB_ENV
+          echo "CGO_ENABLED=1" >> $GITHUB_ENV
+          echo "BUILDTAG=" >> $GITHUB_ENV
+
+      -
+        name: Test
+        if: ${{ matrix.jobs.test == 'test' }}
+        run: |
+          go test ./...
+
+      -
+        name: Build core
+        env:
+          GOOS: ${{matrix.jobs.goos}}
+          GOARCH: ${{matrix.jobs.goarch}}
+          GOAMD64: ${{matrix.jobs.goamd64}}
+          GOARM: ${{matrix.jobs.arm}}
+          GOMIPS: ${{matrix.jobs.mips}}
+        run: |
+          echo $CGO_ENABLED
+          go build -v -trimpath -ldflags "${BUILDTAG} -X 'eat/cmd/version.BuildHash=$(BUILDHASH)' -X 'eat/cmd/version.BuildTime=$(BUILDTIME)' -w -s -buildid=" -o eat.out
+          if [ "${{matrix.jobs.goos}}" = "windows" ]; then
+            mv eat.out eat-${{matrix.jobs.goos}}-${{matrix.jobs.output}}.exe
+            zip -r eat-${{matrix.jobs.goos}}-${{matrix.jobs.output}}-${VERSION}.zip eat-${{matrix.jobs.goos}}-${{matrix.jobs.output}}.exe
+            rm eat-${{matrix.jobs.goos}}-${{matrix.jobs.output}}.exe
+          else
+            mv eat.out eat-${{matrix.jobs.goos}}-${{matrix.jobs.output}}
+            gzip -c eat-${{matrix.jobs.goos}}-${{matrix.jobs.output}} > eat-${{matrix.jobs.goos}}-${{matrix.jobs.output}}-${VERSION}.gz
+            rm eat-${{matrix.jobs.goos}}-${{matrix.jobs.output}}
+          fi
+
+      -
+        name: Save version
+        run: |
+          echo ${VERSION} > version.txt
+        shell: bash
+
+      -
+        name: Archive production artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ matrix.jobs.goos }}-${{ matrix.jobs.output }}"
+          path: |
+            eat*.gz
+            eat*.zip
+            version.txt
+
+  Upload-Release:
+    permissions: write-all
+    if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version != '' }}
+    needs: [ build ]
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: '0'
+          fetch-tags: 'true'
+
+      -
+        name: Get tags
+        run: |
+          echo "CURRENTVERSION=${{ github.event.inputs.version }}" >> $GITHUB_ENV
+          git fetch --tags
+          echo "PREVERSION=$(git describe --tags --abbrev=0 HEAD)" >> $GITHUB_ENV
+
+      -
+        name: Tag the commit
+        run: |
+          git tag ${{ github.event.inputs.version }}
+          git push origin ${{ github.event.inputs.version }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      -
+        name: Generate release notes
+        run: |
+          cp ./.github/gen_release_note_from_commits.sh ./
+          bash ./gen_release_note_from_commits.sh -v ${PREVERSION}...${CURRENTVERSION}
+          rm ./gen_release_note_from_commits.sh
+
+      -
+        uses: actions/download-artifact@v4
+        with:
+          path: dist/
+          merge-multiple: true
+
+      -
+        name: Display structure of downloaded files
+        run: ls -R
+        working-directory: dist/
+
+      -
+        name: Upload Release
+        uses: softprops/action-gh-release@v2
+        if: ${{ success() }}
+        with:
+          tag_name: ${{ github.event.inputs.version }}
+          files: dist/*
+          body_path: release.md

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ go.work
 go.work.sum
 
 .idea
+dist/

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ BUILDTAG=$(shell git rev-parse HEAD)
 endif
 
 BUILDTIME=$(shell date -Iseconds --utc)
-GOBUILD=CGO_ENABLED=0 go build -trimpath -ldflags '-w -s -buildid='
+GOBUILD=CGO_ENABLED=0 go build -trimpath -ldflags '-X "eat/cmd/version.BuildHash=$(BUILDTAG)" \
+													-X "eat/cmd/version.BuildTime=$(BUILDTIME)" \
+													-w -s -buildid='
 
 PLATFORM_LIST = \
 	darwin-amd64-compatible \
@@ -99,7 +101,7 @@ linux-mips64le:
 
 linux-riscv64:
 	GOARCH=riscv64 GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
-	
+
 linux-loong64:
 	GOARCH=loong64 GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME=eat
-BINDIR=dist
+BINDIR=$(shell mkdir -p dist; echo 'dist')
 BRANCH=$(shell git branch --show-current)
 ifeq ($(BRANCH),master) # master production branch
 BUILDTAG=master-$(shell git rev-parse HEAD)
@@ -137,7 +137,8 @@ zip_releases=$(addsuffix .zip, $(WINDOWS_ARCH_LIST))
 
 $(gz_releases): %.gz : %
 	chmod +x $(BINDIR)/$(NAME)-$(basename $@)
-	gzip -f -S -$(BUILDTAG).gz $(BINDIR)/$(NAME)-$(basename $@)
+	gzip -c $(BINDIR)/$(NAME)-$(basename $@) > $(BINDIR)/$(NAME)-$(basename $@)-$(BUILDTAG).gz
+	rm $(BINDIR)/$(NAME)-$(basename $@)
 
 $(zip_releases): %.zip : %
 	zip -m -j $(BINDIR)/$(NAME)-$(basename $@)-$(BUILDTAG).zip $(BINDIR)/$(NAME)-$(basename $@).exe
@@ -153,4 +154,4 @@ lint:
 	golangci-lint run ./...
 
 clean:
-	rm $(BINDIR)/*
+	rm -f $(BINDIR)/*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,154 @@
+NAME=eat
+BINDIR=dist
+BRANCH=$(shell git branch --show-current)
+ifeq ($(BRANCH),master) # master production branch
+BUILDTAG=master-$(shell git rev-parse HEAD)
+else ifeq ($(BRANCH),) # checkout to specific tag
+BUILDTAG=$(shell git describe --tags)
+else # other branch
+BUILDTAG=$(shell git rev-parse HEAD)
+endif
+
+BUILDTIME=$(shell date -Iseconds --utc)
+GOBUILD=CGO_ENABLED=0 go build -trimpath -ldflags '-w -s -buildid='
+
+PLATFORM_LIST = \
+	darwin-amd64-compatible \
+	darwin-amd64 \
+	darwin-arm64 \
+	linux-amd64-compatible \
+	linux-amd64 \
+	linux-armv5 \
+	linux-armv6 \
+	linux-armv7 \
+	linux-arm64 \
+	linux-mips64 \
+	linux-mips64le \
+	linux-mips-softfloat \
+	linux-mips-hardfloat \
+	linux-mipsle-softfloat \
+	linux-mipsle-hardfloat \
+	linux-riscv64 \
+	linux-loong64 \
+	android-arm64 \
+	freebsd-386 \
+	freebsd-amd64 \
+	freebsd-arm64
+
+WINDOWS_ARCH_LIST = \
+	windows-386 \
+	windows-amd64-compatible \
+	windows-amd64 \
+	windows-arm64 \
+    windows-arm32v7
+
+all:linux-amd64 linux-arm64\
+	darwin-amd64 darwin-arm64\
+ 	windows-amd64 windows-arm64\
+
+
+darwin-all: darwin-amd64 darwin-arm64
+
+darwin-amd64:
+	GOARCH=amd64 GOOS=darwin GOAMD64=v3 $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+darwin-amd64-compatible:
+	GOARCH=amd64 GOOS=darwin GOAMD64=v1 $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+darwin-arm64:
+	GOARCH=arm64 GOOS=darwin $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-386:
+	GOARCH=386 GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-amd64:
+	GOARCH=amd64 GOOS=linux GOAMD64=v3 $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-amd64-compatible:
+	GOARCH=amd64 GOOS=linux GOAMD64=v1 $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-arm64:
+	GOARCH=arm64 GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-armv5:
+	GOARCH=arm GOOS=linux GOARM=5 $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-armv6:
+	GOARCH=arm GOOS=linux GOARM=6 $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-armv7:
+	GOARCH=arm GOOS=linux GOARM=7 $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-mips-softfloat:
+	GOARCH=mips GOMIPS=softfloat GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-mips-hardfloat:
+	GOARCH=mips GOMIPS=hardfloat GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-mipsle-softfloat:
+	GOARCH=mipsle GOMIPS=softfloat GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-mipsle-hardfloat:
+	GOARCH=mipsle GOMIPS=hardfloat GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-mips64:
+	GOARCH=mips64 GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-mips64le:
+	GOARCH=mips64le GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+linux-riscv64:
+	GOARCH=riscv64 GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+	
+linux-loong64:
+	GOARCH=loong64 GOOS=linux $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+android-arm64:
+	GOARCH=arm64 GOOS=android $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+freebsd-386:
+	GOARCH=386 GOOS=freebsd $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+freebsd-amd64:
+	GOARCH=amd64 GOOS=freebsd GOAMD64=v3 $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+freebsd-arm64:
+	GOARCH=arm64 GOOS=freebsd $(GOBUILD) -o $(BINDIR)/$(NAME)-$@
+
+windows-386:
+	GOARCH=386 GOOS=windows $(GOBUILD) -o $(BINDIR)/$(NAME)-$@.exe
+
+windows-amd64:
+	GOARCH=amd64 GOOS=windows GOAMD64=v3 $(GOBUILD) -o $(BINDIR)/$(NAME)-$@.exe
+
+windows-amd64-compatible:
+	GOARCH=amd64 GOOS=windows GOAMD64=v1 $(GOBUILD) -o $(BINDIR)/$(NAME)-$@.exe
+
+windows-arm64:
+	GOARCH=arm64 GOOS=windows $(GOBUILD) -o $(BINDIR)/$(NAME)-$@.exe
+
+windows-arm32v7:
+	GOARCH=arm GOOS=windows GOARM=7 $(GOBUILD) -o $(BINDIR)/$(NAME)-$@.exe
+
+gz_releases=$(addsuffix .gz, $(PLATFORM_LIST))
+zip_releases=$(addsuffix .zip, $(WINDOWS_ARCH_LIST))
+
+$(gz_releases): %.gz : %
+	chmod +x $(BINDIR)/$(NAME)-$(basename $@)
+	gzip -f -S -$(BUILDTAG).gz $(BINDIR)/$(NAME)-$(basename $@)
+
+$(zip_releases): %.zip : %
+	zip -m -j $(BINDIR)/$(NAME)-$(basename $@)-$(BUILDTAG).zip $(BINDIR)/$(NAME)-$(basename $@).exe
+
+all-arch: $(PLATFORM_LIST) $(WINDOWS_ARCH_LIST)
+
+releases: $(gz_releases) $(zip_releases)
+
+vet:
+	go test ./...
+
+lint:
+	golangci-lint run ./...
+
+clean:
+	rm $(BINDIR)/*

--- a/README.md
+++ b/README.md
@@ -35,25 +35,25 @@ Flags:
 ```
 
 ```shell
-eat -c 4										# eating 4 CPU core
-eat -c 35%										# eating 35% CPU core (CPU count * 35%)
-eat -c 100%										# eating all CPU core
-eat -m 4g										# eating 4GB memory
-eat -m 20m										# eating 20MB memory
-eat -m 35%										# eating 35% memory (total memory * 35%)
-eat -m 100%										# eating all memory
-eat -c 2.5 -m 1.5g								# eating 2.5 CPU core and 1.5GB memory
-eat -c 3 -m 200m								# eating 3 CPU core and 200MB memory
-eat -c 100% -m 100%								# eating all CPU core and memory
-eat -c 100% -t 1h								# eating all CPU core and quit after 1hour
+eat -c 4		# eating 4 CPU core
+eat -c 35%		# eating 35% CPU core (CPU count * 35%)
+eat -c 100%		# eating all CPU core
+eat -m 4g		# eating 4GB memory
+eat -m 20m		# eating 20MB memory
+eat -m 35%		# eating 35% memory (total memory * 35%)
+eat -m 100%		# eating all memory
+eat -c 2.5 -m 1.5g	# eating 2.5 CPU core and 1.5GB memory
+eat -c 3 -m 200m	# eating 3 CPU core and 200MB memory
+eat -c 100% -m 100%	# eating all CPU core and memory
+eat -c 100% -t 1h	# eating all CPU core and quit after 1hour
 
-eat --cpu-affinities 0 -c 1						# only run eat in core #0 (first core)
-eat --cpu-affinities 0,1 -c 2					# run eat in core #0,1 (first and second core)
-eat --cpu-affinities 0,1,2,3 -c 100% 			# error case: in-enough cpu affinities
+eat --cpu-affinities 0 -c 1	# only run eat in core #0 (first core)
+eat --cpu-affinities 0,1 -c 2	# run eat in core #0,1 (first and second core)
+eat --cpu-affinities 0,1,2,3 -c 100% # error case: in-enough cpu affinities
 # Have 8C15G.
 # Error: failed to parse cpu affinities, reason: each request cpu cores need specify its affinity, aff 4 < req 8
-eat --cpu-affinities 0,1,2,3 -c 50%				# run eat in core #0,1,2,3 (first to fourth core)
-eat --cpu-affinities 0,1,2,3,4,5,6,7 -c 92% 	# run eat in all core(full of 7 cores, part of last core)
+eat --cpu-affinities 0,1,2,3 -c 50%	# run eat in core #0,1,2,3 (first to fourth core)
+eat --cpu-affinities 0,1,2,3,4,5,6,7 -c 92%	# run eat in all core(full of 7 cores, part of last core)
 
 ```
 
@@ -64,11 +64,11 @@ eat --cpu-affinities 0,1,2,3,4,5,6,7 -c 92% 	# run eat in all core(full of 7 cor
 
 ```shell
 # Linux
-GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat
+make linux-amd64 linux-arm64
 # macOs
-GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat_mac
+make darwin-amd64 darwin-arm64
 # Windows
-GOOS=windwos GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat_win
+make windows-amd64 windows-arm64
 ```
 
 # 介绍
@@ -81,7 +81,7 @@ GOOS=windwos GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat_win
 - [x] 支持`eat -c 35%`和`eat -m 35%`
 - [x] 支持优雅退出: 捕捉进程 SIGINT, SIGTERM 信号实现有序退出
 - [x] 支持时限: `-t` 限制吃资源的时间，示例 "300ms", "1.5h", "2h45m". (单位: "ns", "us" (or "µs"), "ms", "s", "m", "h")
-- [x] CPU亲和性
+- [x] CPU亲和性(绑定 CPU 核心)
   - [X] Linux 
   - [ ] macOS
   - [ ] Windows
@@ -100,34 +100,34 @@ $ ./eat.out --help
     eat [flags］
 
 Flags：
-  --cpu-affinities 整数						指定在几个核心上运行 Eat，多个核心索引之间用 ',' 分隔，索引从 0 开始。
-  -c, --cpu-usage 字符串						你想吃掉多少个 CPU（默认为 '0'）？
-  -h，--help								输出 eat 的帮助
-  -r, --memory-refresh-interval 字符串		每隔多长时间触发一次刷新，以防止被吃掉的内存被交换出去（默认值为 '5m'）
-  -m, --memory-usage 字符串					你希望吃掉多少内存（GB）（默认值 '0m'）
-  -t，--time-deadline 字符串					退出 eat 进程的截止日期（默认为 "0'）。
+  --cpu-affinities 			整数	指定在几个核心上运行 Eat，多个核心索引之间用 ',' 分隔，索引从 0 开始。
+  -c, --cpu-usage 			字符串	你想吃掉多少个 CPU（默认为 '0'）？
+  -h，--help				输出 eat 的帮助
+  -r, --memory-refresh-interval 字符串	每隔多长时间触发一次刷新，以防止被吃掉的内存被交换出去（默认值为 '5m'）
+  -m, --memory-usage 字符串		你希望吃掉多少内存（GB）（默认值 '0m'）
+  -t，--time-deadline 字符串		退出 eat 进程的截止日期（默认为 "0'）。
 ```
 
 ```shell
-eat -c 4									# 占用4个CPU核
-eat -c 35%									# 占用35%CPU核（CPU核数 * 35%）
-eat -c 100%									# 占用所有CPU核
-eat -m 4g									# 占用4GB内存
-eat -m 20m									# 占用20MB内存
-eat -m 35%									# 占用35%内存（总内存 * 35%）
-eat -m 100%									# 占用所有内存
-eat -c 2.5 -m 1.5g							# 占用2.5个CPU核和1.5GB内存
-eat -c 3 -m 200m							# 占用3个CPU核和200MB内存
-eat -c 100% -m 100%							# 占用所有CPU核和内存
-eat -c 100% -t 1h							# 占用所有CPU核并在一小时后退出
+eat -c 4	# 占用4个CPU核
+eat -c 35%	# 占用35%CPU核（CPU核数 * 35%）
+eat -c 100%	# 占用所有CPU核
+eat -m 4g	# 占用4GB内存
+eat -m 20m	# 占用20MB内存
+eat -m 35%	# 占用35%内存（总内存 * 35%）
+eat -m 100%	# 占用所有内存
+eat -c 2.5 -m 1.5g	# 占用2.5个CPU核和1.5GB内存
+eat -c 3 -m 200m	# 占用3个CPU核和200MB内存
+eat -c 100% -m 100%	# 占用所有CPU核和内存
+eat -c 100% -t 1h	# 占用所有CPU核并在一小时后退出
 
-eat --cpu-affinities 0 -c 1					# 只占用 #0 第一个核心
-eat --cpu-affinities 0,1 -c 2				# 占用 #0,1 前两个个核心
-eat --cpu-affinities 0,1,2,3 -c 100% 		# 错误参数: 每个请求核都要指定对应的亲和性核心
+eat --cpu-affinities 0 -c 1	# 只占用 #0 第一个核心
+eat --cpu-affinities 0,1 -c 2	# 占用 #0,1 前两个个核心
+eat --cpu-affinities 0,1,2,3 -c 100%	# 错误参数: 每个请求核都要指定对应的亲和性核心
 # Have 8C15G.
-# Error: failed to parse cpu affinities, reason: each request cpu cores need specify its affinity, aff 4 < phy 8
+# Error: failed to parse cpu affinities, reason: each request cpu cores need specify its affinity, aff 4 < req 8
 # 出错: 无法解析 CPU 亲和性, 原因: 每个请求核都要指定对应的亲和性核心, 亲和核  4 < 请求核 8
-eat --cpu-affinities 0,1,2,3 -c 50%			# 占用前4个核心
+eat --cpu-affinities 0,1,2,3 -c 50%	# 占用前4个核心
 eat --cpu-affinities 0,1,2,3,4,5,6,7 -c 92%	# 占用前8个核心 (全部7个核心，部分的最后一个核心)
 ```
 
@@ -138,9 +138,9 @@ eat --cpu-affinities 0,1,2,3,4,5,6,7 -c 92%	# 占用前8个核心 (全部7个核
 
 ```shell
 # Linux
-GOOS=linux GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat
+make linux-amd64 linux-arm64
 # macOs
-GOOS=darwin GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat_mac
+make darwin-amd64 darwin-arm64
 # Windows
-GOOS=windwos GOARCH=amd64 go build -trimpath -ldflags "-s -w" -v -o eat_win
+make windows-amd64 windows-arm64
 ```

--- a/cmd/memory.go
+++ b/cmd/memory.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	unimem "github.com/pbnjay/memory"
 	"log"
 	"sync"
 	"time"
+
+	unimem "github.com/pbnjay/memory"
 )
 
 // ActiveMemoryManager struct to encapsulate buffers and related methods
@@ -33,7 +34,7 @@ func (m *ActiveMemoryManager) AllocateMemory(ctx context.Context) error {
 	if m.size > curFreeSize {
 		return fmt.Errorf("free memory not enough: %d > %d", m.size, curFreeSize)
 	}
-	//split request memory to multiple small-size chunks
+	// split request memory to multiple small-size chunks
 	const unitChunk = chunkSizeMemoryWorkerEachAllocate
 	nChunks := m.size / unitChunk
 	remain := m.size % unitChunk

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 	"time"
 
+	"eat/cmd/version"
 	"github.com/pbnjay/memory"
 	"github.com/spf13/cobra"
 )
@@ -24,9 +25,10 @@ func getCPUAndMemory() (uint64, uint64) {
 }
 
 var RootCmd = &cobra.Command{
-	Use:   "eat",
-	Short: "A monster that eats cpu and memory 🦕",
-	Run:   eatFunction,
+	Use:     "eat",
+	Short:   "A monster that eats cpu and memory 🦕",
+	Version: version.Version,
+	Run:     eatFunction,
 }
 
 func getConsoleHelpTips(deadline time.Duration) string {
@@ -77,6 +79,7 @@ func getRootContext(dlEat time.Duration) (context.Context, context.CancelFunc) {
 }
 
 func eatFunction(cmd *cobra.Command, _ []string) {
+	fmt.Printf("version: %s, build time: %s, build hash: %s\n", version.Version, version.BuildTime, version.BuildHash)
 	cpuCount, memoryBytes := getCPUAndMemory()
 	fmt.Printf("Have %dC%dG.\n", cpuCount, memoryBytes/1024/1024/1024)
 

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -1,0 +1,7 @@
+package version
+
+var (
+	Version   = "0.1.3"
+	BuildHash = "unknown hash" // will insert in build time
+	BuildTime = "unknown time" // will insert in build time
+)


### PR DESCRIPTION
## 1 Introduce

Right now there is no workflow for this project that automatically builds executables for all operating systems and architectures when a new version is released. 

This is very important for those **non-expert users** (e.g. testers), we can't assume that all end-users are willing to clone the project locally and compile the desired platform artifacts themselves.

## 2 Features

I added makefile and github workflows for auto build artifacts in local and remote respectively.

### 2.1 add Makefile

> build in local

![image](https://github.com/user-attachments/assets/cb0dc238-fe84-448d-a22c-c2af953cf84d)


### 2.2 add GitHub workflow

> build in remote (via Github Action, just one click to run) 

![image](https://github.com/user-attachments/assets/a7be63b8-fc52-459c-a0ae-701885db7722)

![R6ioFckH07](https://github.com/user-attachments/assets/74781c59-46b2-419d-9195-3cc78000c267)



### 2.3 add build time and hash 

- [x] inject build time and hash when building exe(from git commit of current branch): for better issue report and troubleshot 

![image](https://github.com/user-attachments/assets/42db09af-c1b6-4e19-9470-20851bafa7e6)


## Release Preview

Note: the workflow will also generate release note from commits between current version and last version.

![image](https://github.com/user-attachments/assets/c75885b4-ca07-4274-8f2e-11a5f568a3cb)


Now you can easily share `eat` with your friends or coworkers, privately or publicly. :)
